### PR TITLE
Echo relay agent info back on replies if present (option 82)

### DIFF
--- a/main.go
+++ b/main.go
@@ -92,7 +92,8 @@ func modifiersFromNicConfig(nicConfig *types.NicConfig, ipNet *net.IPNet) ([]dhc
 }
 
 func withRelayAgentInfo(o *dhcpv4.RelayOptions) dhcpv4.Modifier {
-	options := make([]dhcpv4.Option, len(o.Options))
+	options := []dhcpv4.Option{}
+	log.Printf("options: %v", options)
 	for code, value := range o.Options {
 		options = append(options, dhcpv4.OptGeneric(dhcpv4.GenericOptionCode(code), value))
 	}

--- a/main.go
+++ b/main.go
@@ -168,13 +168,13 @@ func (d *DHCPServer) createOfferPacket(m *dhcpv4.DHCPv4) (*dhcpv4.DHCPv4, error)
 		return nil, err
 	}
 
+	// Append Offer Message Type
+	modifiers = append(modifiers, dhcpv4.WithMessageType(dhcpv4.MessageTypeOffer))
+
 	relayInfo := m.RelayAgentInfo()
 	if relayInfo != nil {
 		modifiers = append(modifiers, withRelayAgentInfo(relayInfo))
 	}
-
-	// Append Offer Message Type
-	modifiers = append(modifiers, dhcpv4.WithMessageType(dhcpv4.MessageTypeOffer))
 
 	return dhcpv4.NewReplyFromRequest(m, modifiers...)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -74,6 +74,7 @@ func TestCreateOfferPacket(t *testing.T) {
 	mockIP, mockNet, _ := net.ParseCIDR("192.168.1.10/24")
 	mac, _ := net.ParseMAC("01:23:45:67:89:ab")
 	mockRequest, _ := dhcpv4.NewDiscovery(mac)
+
 	expectedPacket, _ := dhcpv4.NewReplyFromRequest(mockRequest,
 		dhcpv4.WithYourIP(mockIP),
 		dhcpv4.WithNetmask(mockNet.Mask),
@@ -86,6 +87,55 @@ func TestCreateOfferPacket(t *testing.T) {
 		dhcpv4.WithServerIP(net.ParseIP("192.168.1.50")),
 		dhcpv4.WithOption(dhcpv4.OptServerIdentifier(net.ParseIP("192.168.1.254"))),
 		dhcpv4.WithLeaseTime(3600),
+	)
+
+	mockServer := DHCPServer{
+		Inventory: MockInventory{},
+		Config: DHCPServerConfig{
+			IPNet:            mockNet.String(),
+			NextServer:       "192.168.1.50",
+			Filename:         "test.img",
+			ServerIdentifier: "192.168.1.254",
+		},
+	}
+
+	packet, err := mockServer.createOfferPacket(mockRequest)
+	if err != nil {
+		t.Errorf("got error creating offer packet: %v", err)
+	}
+
+	if !reflect.DeepEqual(expectedPacket, packet) {
+		t.Errorf("modified offer packet is not equal to expected: \n Expected: %s \n Got: %s", expectedPacket.Summary(), packet.Summary())
+	}
+
+}
+
+func TestCreateOfferPacketWithOption82(t *testing.T) {
+
+	mockIP, mockNet, _ := net.ParseCIDR("192.168.1.10/24")
+	mac, _ := net.ParseMAC("01:23:45:67:89:ab")
+	mockRequest, _ := dhcpv4.NewDiscovery(mac)
+	dhcpv4.WithGeneric(dhcpv4.OptionRelayAgentInformation, []byte{
+		1, 5, 'l', 'i', 'n', 'u', 'x',
+		2, 4, 'b', 'o', 'o', 't',
+	})(mockRequest)
+
+	expectedPacket, _ := dhcpv4.NewReplyFromRequest(mockRequest,
+		dhcpv4.WithYourIP(mockIP),
+		dhcpv4.WithNetmask(mockNet.Mask),
+		dhcpv4.WithDNS(net.ParseIP("192.168.1.5")),
+		dhcpv4.WithRouter(net.ParseIP("192.168.1.1")),
+		dhcpv4.WithOption(dhcpv4.OptHostName("test-node-00")),
+		dhcpv4.WithOption(dhcpv4.OptTFTPServerName("192.168.1.50")),
+		dhcpv4.WithOption(dhcpv4.OptBootFileName("test.img")),
+		dhcpv4.WithMessageType(dhcpv4.MessageTypeOffer),
+		dhcpv4.WithServerIP(net.ParseIP("192.168.1.50")),
+		dhcpv4.WithOption(dhcpv4.OptServerIdentifier(net.ParseIP("192.168.1.254"))),
+		dhcpv4.WithLeaseTime(3600),
+		dhcpv4.WithGeneric(dhcpv4.OptionRelayAgentInformation, []byte{
+			1, 5, 'l', 'i', 'n', 'u', 'x',
+			2, 4, 'b', 'o', 'o', 't',
+		}),
 	)
 
 	mockServer := DHCPServer{


### PR DESCRIPTION
If the relay agent attaches option 82, we need to echo that back.  [RFC 3046](https://tools.ietf.org/html/rfc3046#section-2.2)